### PR TITLE
fix: Correct backend port for demo-http-route to 80 for service reachability

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,5 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
----
+      port: 80


### PR DESCRIPTION
This PR fixes the backend port for the demo-http-route HTTPRoute resource. The previous port 8080 did not match the demo service port 80, causing routing failures from the Istio ingress gateway. Correcting it to port 80 should restore connectivity.