### PR TITLE
fix: add annotation to demo-http-route to force reapply and fix port

### DIFF
--- a/policy/demo-http-route.yaml
+++ b/policy/demo-http-route.yaml
@@ -3,6 +3,8 @@ kind: HTTPRoute
 metadata:
   name: demo-http-route
   namespace: default
+  annotations:
+    force-reapply: "true"
 spec:
   parentRefs:
   - name: ingress-gateway


### PR DESCRIPTION
This patch adds an annotation to demo-http-route HTTPRoute manifest to force ArgoCD to reapply the resource. This will update the incorrectly applied backend port 8080 to the correct port 80 and fix the ingress gateway connectivity issue.