### PR TITLE
fix: update HTTPRoute backendRef port to 80 to match demo service

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
Fixed the backendRef port in demo-http-route.yaml from 8080 to 80 to match the demo service port. This resolves the issue where the demo service was unreachable via the Istio ingress gateway.