### PR TITLE
fix: correct HTTPRoute backendRef port for demo service

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -11,8 +11,8 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: /
+        value: "/"
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the incorrect port in the HTTPRoute resource `demo-http-route.yaml`. The backendRef port was set to `8080` but the demo service exposes port `80`. Correcting this to ensure ingress routes properly to the demo service.