### PR TITLE
fix: update HTTPRoute backendRef port from 8080 to 80 for demo service ingress routing

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
### Summary
Fix mismatch in HTTPRoute backendRef port for demo service from 8080 to 80. This aligns the HTTPRoute with the demo service port to enable correct ingress routing.

### Changes
- Updated `demo-http-route.yaml` to set backendRef port to 80.

### Verification
- After merge and ArgoCD sync, demo service should be reachable via Istio ingress gateway.

Closes: #issue-if-any
