### PR TITLE
Fix: Correct demo-http-route service port

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR corrects the target port for the `demo` service in the `demo-http-route` from `8080` to `80`. This resolves the issue where the service was unreachable from the Istio ingress gateway due to a port mismatch.