### PR TITLE
Fix: Update Ollama Base URL for in-cluster access

### DIFF
--- a/kubernetes/demo.yaml
+++ b/kubernetes/demo.yaml
@@ -41,7 +41,7 @@ spec:
             - containerPort: 8001
           env:
             - name: OLLAMA_BASE_URL
-              value: "http://host.docker.internal:11434"
+              value: "http://ollama-service.default.svc.cluster.local:11434"
               # value: "http://ollama.ollama:80"
             # - name: SECRET_OPENAI
               # valueFrom:


### PR DESCRIPTION
This PR updates the OLLAMA_BASE_URL environment variable in kubernetes/demo.yaml to point to the in-cluster Ollama service, resolving connectivity issues within the Kubernetes environment.