### PR TITLE
Fix: Demo HTTPRoute Port Mismatch

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the port mismatch in the demo-http-route, changing the backendRefs port from 8080 to 80 to align with the demo service's actual listening port.