### PR TITLE
Fix: Correct demo service backend port in HTTPRoute

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8001
+      port: 80

--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 8001


### PR DESCRIPTION
This PR fixes the backend port for the demo service in the HTTPRoute configuration. The service's target port is 8001, but the HTTPRoute was configured for port 8080, causing connectivity issues.