### PR TITLE
Fix: Correct demo-http-route backendRefs port

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8080
+      port: 80


### PR DESCRIPTION
This PR fixes the connectivity issue between agentgateway and demo services by correcting the backendRefs port in the demo-http-route from 8080 to 80.