### PR TITLE
Fix: Demo service port in HTTPRoute

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 80


### PR DESCRIPTION
This PR fixes the connectivity issue by updating the `demo-http-route` to use the correct port (80) for the `demo` service. Previously, it was configured to use port 88, leading to a port mismatch.