### PR TITLE
Fix: Update demo-http-route to use port 8001

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8001
+      port: 80

--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -16,4 +16,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 8001


### PR DESCRIPTION
This PR fixes the connectivity issue for the demo service by updating the HTTPRoute to use the correct backend port 8001.