### PR TITLE
Fix: Correct HTTPRoute port for demo service

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 8001

--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 8001
+      port: 80


### PR DESCRIPTION
This PR corrects the `backendRefs.port` in the `demo-http-route` from `88` to `8001`. This resolves the 503 error encountered when `agentgateway` attempted to reach the `demo` service, as the `demo` service's pods are actually listening on port `8001`.