### PR TITLE
Fix: Correct demo-http-route backend service port

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 80


### PR DESCRIPTION
This PR corrects the backendRefs port for the demo service in the demo-http-route. The port was incorrectly set to 88 and has been changed to 80 to match the demo service's exposed port.