### PR TITLE
Fix: demo-http-route backendRef port mismatch

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 80


### PR DESCRIPTION
This PR corrects the `backendRefs` port for the `demo` service in the `demo-http-route` HTTPRoute from `88` to `80`, resolving the connectivity issue from `agentgateway`.