### PR TITLE
Fix port mismatch in HTTPRoute for demo service

### DIFF
--- a/kubernetes/demo-http-route.yaml
+++ b/kubernetes/demo-http-route.yaml
@@ -15,4 +15,4 @@ spec:
     backendRefs:
     - name: demo
       kind: Service
-      port: 88
+      port: 80


### PR DESCRIPTION
### Summary

This PR fixes the port mismatch in the HTTPRoute configuration for the demo service.

- **Changed Port in HTTPRoute**: Updated from `88` to `80` to match the service port.

### Impact

This change allows the `agentgateway` in the `kgateway-system` namespace to correctly route traffic to the `demo` service in the `default` namespace.

### Verification

Please verify the PR and allow ArgoCD to sync the changes to ensure connectivity is restored.